### PR TITLE
correcting PUBLIC_URL on homepage/marcos

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,7 +86,7 @@ function HomePage() {
       <header className="header" style={{ background: theme.headerFooter, color: theme.text }}>
         <div className="header-left">
           <div className="menu-icon">
-            <img src="/favicon-32x32.png" alt="Career Helpi Logo" />
+            <img src={process.env.PUBLIC_URL + '/favicon-32x32.png'} alt="Career Helpi Logo" />
           </div>
           <h1 className="website-title">Career Helpi</h1>
         </div>


### PR DESCRIPTION
Sprint 3
User Stories: 2.5 (#45), 2 (#9), 1 (#5)
Epic(s): 2 (#8), 1 (#3)
Story Pts: 2

Summary:
I remade our homepage to include our new favicon as our logo, redid our navbar to include our "name" (Career Helpi), and added a link to a non-existant page (for now) called About Us. I redid the sizing of our buttons to our Short and Detailed Quiz as well as making our OpenAI API Key textbox look more polished. I did this to make this part of the site look more cohesive to the rest as well as reworking our dark theme to utilize our color scheme more, as before our light theme was the only one utilizing our accent color scheme.

Note:
This was committed a 3rd time due to the favicon not loading because of the img not using PUBLIC_URL in front of it making it not load.